### PR TITLE
AllowAPBarforAllJobs menu shrink fix

### DIFF
--- a/Scripts/Patches/AllowAPBarforAllJobs.qjs
+++ b/Scripts/Patches/AllowAPBarforAllJobs.qjs
@@ -83,6 +83,12 @@ AllowAPBarforAllJobs = function()
     );
 
     // -------------------------------
+    applyPattern(
+        "E8 ?? ?? ?? ?? 8B 4E ?? 3C 01 75 ?? 83 F9 47 74 ?? 81 F9 95 00 00 00",
+        8, "90 90 90 90", "Pattern5 (cmp al,1 / jne ??)"
+    );
+
+    // -------------------------------
     let pos = 0;
     let cntC7 = 0;
     const c7Pattern = "C7 40 24 00 00 00 00 75 ??";


### PR DESCRIPTION
Addressed issue: #23

This disables a jump after a class IV range check call, that that was causing the auto reducing menu when applying the patch.
This was tested on 2021 and 2025.