### PR TITLE
Fixes Increase Zoom out by 75%

### DIFF
--- a/Patches/Client.yml
+++ b/Patches/Client.yml
@@ -260,7 +260,7 @@ IncrZoom:
         - Zoom75Percent:
             title : Increase Zoom Out (to 75%)
             recommend : no
-            author : Shinryo , Andrei Karas (4144)
+            author : Shinryo , Andrei Karas (4144) , Functor
             desc : Increases the zoom-out range to approx. 75% of Maximum.
         
         - ZoomMax:

--- a/Scripts/Patches/IncrZoom.qjs
+++ b/Scripts/Patches/IncrZoom.qjs
@@ -51,6 +51,6 @@ ZoomMax       = IncrZoom;
 IncrZoom.Data = MakeMap(
     'Zoom25Percent', "00 00 00 43 00 00",
     'Zoom50Percent', "00 00 FF 43 00 00",
-    'Zoom75Percent', "00 00 4C 44 00 00",
+	'Zoom75Percent', "00 80 36 44 00 00",
     'ZoomMax',       "00 00 99 44 00 00" 
 );


### PR DESCRIPTION
* **Description of Pull Request**:
This PR introduces a fix for the 75% Zoom Out issue when using Gepard Shield. Special Thanks to Functor for the proper hex values.

* **Addressed Issue**: https://github.com/hiphop9/Warp2025/issues/31
* **Context**:
<img width="938" height="362" alt="image" src="https://github.com/user-attachments/assets/8e681cd5-b659-480f-9dbd-3ae36bba3277" />
