### PR TITLE
Added Zoom67Percent value on IncrZoom Patch

### DIFF
--- a/Patches/Client.yml
+++ b/Patches/Client.yml
@@ -257,11 +257,17 @@ IncrZoom:
             author : Shinryo , Andrei Karas (4144)
             desc : Increases the zoom-out range to approx. 50% of Maximum.
         
+        - Zoom67Percent:
+            title : Increase Zoom Out (to 67%)
+            recommend : no
+            author : Shinryo , Andrei Karas (4144) , Daraen1
+            desc : Increases the zoom-out range to approx. 67% of Maximum.
+        
         - Zoom75Percent:
             title : Increase Zoom Out (to 75%)
             recommend : no
-            author : Shinryo , Andrei Karas (4144) , Daraen1
-            desc : Increases the zoom-out range to approx. 75% of Maximum.
+            author : Shinryo , Andrei Karas (4144)
+            desc : Increases the zoom-out range to approx. 75% of Maximum. (Doesn't work on Gepard Shield)
         
         - ZoomMax:
             title : Increase Zoom Out (to Max)

--- a/Patches/Client.yml
+++ b/Patches/Client.yml
@@ -260,7 +260,7 @@ IncrZoom:
         - Zoom75Percent:
             title : Increase Zoom Out (to 75%)
             recommend : no
-            author : Shinryo , Andrei Karas (4144) , Functor
+            author : Shinryo , Andrei Karas (4144) , Daraen1
             desc : Increases the zoom-out range to approx. 75% of Maximum.
         
         - ZoomMax:

--- a/Patches/Client.yml
+++ b/Patches/Client.yml
@@ -267,7 +267,7 @@ IncrZoom:
             title : Increase Zoom Out (to 75%)
             recommend : no
             author : Shinryo , Andrei Karas (4144)
-            desc : Increases the zoom-out range to approx. 75% of Maximum. (Doesn't work on Gepard Shield)
+            desc : Increases the zoom-out range to approx. 75% of Maximum. (Doesn't work with Gepard Shield)
         
         - ZoomMax:
             title : Increase Zoom Out (to Max)

--- a/Scripts/Patches/IncrZoom.qjs
+++ b/Scripts/Patches/IncrZoom.qjs
@@ -8,7 +8,7 @@
 \**************************************************************************/
 
 ///
-/// \brief Modify Zoom to specific percentages (25%, 50%, 75%, Maximum)
+/// \brief Modify Zoom to specific percentages (25%, 50%, 67%, 75%, Maximum)
 ///
 IncrZoom = function(_) {
     $$(_, 1.1, `Search for the default zoom pattern in the executable`)
@@ -42,6 +42,7 @@ IncrZoom = function(_) {
 ///
 Zoom25Percent = IncrZoom;
 Zoom50Percent = IncrZoom;
+Zoom67Percent = IncrZoom;
 Zoom75Percent = IncrZoom;
 ZoomMax       = IncrZoom;
 
@@ -51,6 +52,7 @@ ZoomMax       = IncrZoom;
 IncrZoom.Data = MakeMap(
     'Zoom25Percent', "00 00 00 43 00 00",
     'Zoom50Percent', "00 00 FF 43 00 00",
-	'Zoom75Percent', "00 80 36 44 00 00",
+	'Zoom67Percent', "00 80 36 44 00 00",
+	'Zoom75Percent', "00 80 4C 44 00 00",
     'ZoomMax',       "00 00 99 44 00 00" 
 );


### PR DESCRIPTION
* **Description of Pull Request**:
This PR restores the original values of the `Zoom75Percent` patch and adds a `Zoom67Percent` patch that works with Gepard Shield. Also corrects a typo in the contributor credits from the previous [PR](https://github.com/hiphop9/Warp2025/pull/43) that has been already merged.

* **Remarks**:
Since `Zoom75Percent` does not work with Gepard Shield, @daraen1 provided the values for the new 67% zoom-out patch that works with Gepard Shield.

<img width="802" height="632" alt="95" src="https://github.com/user-attachments/assets/1ebbb11a-d9b9-41ee-8f09-b86b42ef335e" />
